### PR TITLE
Mount Amazon EFA libraries in Singularity

### DIFF
--- a/scripts/s3/slurm/slurm.taskprolog
+++ b/scripts/s3/slurm/slurm.taskprolog
@@ -68,9 +68,10 @@
   # If Intel MPI is loaded and not included in the Singularity list, add its libraries
   if [[ -n ${I_MPI_ROOT} && ${SINGULARITY_CONTAINLIBS} != *${I_MPI_ROOT}* ]]; then
     I_MPI_LIBRARIES=$(find ${I_MPI_ROOT}/lib/{,mpi} -maxdepth 1 -type "f,l" | grep -vE "debug|release" | tr '\n' ',')
+    EFA_LIBRARIES=$(find /opt/amazon/efa/lib64 -maxdepth 1 -type "f,l" | tr '\n' ',')
     echo "export SINGULARITY_BIND=$(echo -n ${I_MPI_ROOT}/libfabric/lib,${I_MPI_ROOT}/etc,${SINGULARITY_BIND} | sed -r "s|(.*),$|\1|")"
-    echo "export SINGULARITY_CONTAINLIBS=$(echo -n ${I_MPI_LIBRARIES}${SINGULARITY_CONTAINLIBS} | sed -r "s|(.*),$|\1|")"
-    echo "export SINGULARITYENV_LD_PRELOAD=/.singularity.d/libs/libmpi.so"
+    echo "export SINGULARITY_CONTAINLIBS=$(echo -n ${I_MPI_LIBRARIES}${EFA_LIBRARIES}${SINGULARITY_CONTAINLIBS} | sed -r "s|(.*),$|\1|")"
+    echo "export SINGULARITYENV_LD_PRELOAD=/.singularity.d/libs/libmpi.so:/.singularity.d/libs/libfabric.so"
     # Check whether "EFA" is supported in this compute instance and force enable it if it is
     if [[ -n $(fi_info -p efa -t FI_EP_RDM 2>&1 | grep -e "provider: efa") ]]; then
         echo "export I_MPI_OFI_LIBRARY_INTERNAL=0"


### PR DESCRIPTION
While testing the Neurodamus container deployments, they failed on nodes with Amazon Elastic Fiber Adapter with the following:

```
[0] MPI startup(): libfabric version: 1.19.0
Abort(2139023) on node 0 (rank 0 in comm 0): Fatal error in PMPI_Init: Unknown error class, error stack:
MPIR_Init_thread(192)........:
MPID_Init(1665)..............:
MPIDI_OFI_mpi_init_hook(1625):
open_fabric(2726)............:
find_provider(2904)..........: OFI fi_getinfo() failed (ofi_init.c:2904:find_provider:No data available)
```

This is because it tries to use the `efa` fabric provider (we set `I_MPI_OFI_PROVIDER=efa` in the same section of the `slurm.taskprolog`) but the `libfabric.so` found in the container does not have this provider. 

The fix is to mount Amazon's `libfabric` through `SINGULARITY_CONTAINLIBS` and LD-preload it inside: I tested it on the (still) running instance of the parallelcluster.

I realize this code will not be deployed in the future (superseded by https://github.com/BlueBrain/hpc-resource-provisioner), but for the sake of knowledge transfer, it would be useful to merge the fix nonetheless?